### PR TITLE
fix(chromium-bus): correct typo in tabs.query

### DIFF
--- a/drivers/chromium-bus.js
+++ b/drivers/chromium-bus.js
@@ -16,7 +16,12 @@ ChromiumBus.prototype.publish = function publish(event) {
 
     function executeOnCurrentTab(executor) {
         if (chrome.tabs) {
-            chrome.tabs.query({ active: true, currentWindow: true, typeWindow: 'normal' }, function getCurrentTabId(currentTabs) {
+            chrome.tabs.query({
+                active: true,
+                currentWindow: true,
+                windowType: 'normal'
+            },
+            function getCurrentTabId(currentTabs) {
                 if (currentTabs[0]) executor(currentTabs[0]);
             });
         }


### PR DESCRIPTION
Change `typeWindow` by `windowType`. 
See https://developer.chrome.com/extensions/tabs#method-query
